### PR TITLE
Canonicalize quaternion sign in log_map to return the geodesic tangent

### DIFF
--- a/src/so3.rs
+++ b/src/so3.rs
@@ -333,9 +333,18 @@ impl<T: na::Scalar + na::ComplexField + na::RealField + Copy> SO3<T> {
         SO3::hat(&SO3::log_map(q))
     }
 
+    /// Logarithmic chart map: SO(3) -> R^3.
+    ///
+    /// The quaternion sign is canonicalized (`q_w >= 0`) before taking the log, so that the
+    /// geodesic (shortest) rotation vector is returned. Without this, a quaternion with negative
+    /// scalar part (which represents the same rotation as its negation) would map to the
+    /// complementary rotation of magnitude near `2*pi`.
     pub fn log_map(q: &SO3<T>) -> na::Vector3<T> {
-        let qv = na::Vector3::new(q.x(), q.y(), q.z());
-        let qw = q.w();
+        let (qv, qw) = if q.w() < T::zero() {
+            (na::Vector3::new(-q.x(), -q.y(), -q.z()), -q.w())
+        } else {
+            (na::Vector3::new(q.x(), q.y(), q.z()), q.w())
+        };
         let n = qv.norm();
         if n > na::convert(1e-4) {
             qv * (na::convert::<f64, T>(2.0) * n.atan2(qw) / n)
@@ -790,6 +799,21 @@ mod test {
         assert!((qr.x() - qr3.x()).abs() < EPSILON);
         assert!((qr.y() - qr3.y()).abs() < EPSILON);
         assert!((qr.z() - qr3.z()).abs() < EPSILON);
+    }
+
+    #[test]
+    fn test_log_double_cover() {
+        // q and -q represent the same rotation: log_map must return the
+        // geodesic (shortest) rotation vector for both, never the 2*pi
+        // complement.
+        let num_tests = 50;
+        for _ in 0..num_tests {
+            let w: Vector3<f64> = Vector3::new_random() - Vector3::new(0.5, 0.5, 0.5);
+            let q = SO3::exp_map(&w);
+            let q_neg = SO3::from_quat(-q.w(), -q.x(), -q.y(), -q.z());
+            assert!((SO3::log_map(&q) - w).norm() < EPSILON);
+            assert!((SO3::log_map(&q_neg) - w).norm() < EPSILON);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`log_map` maps quaternions with negative scalar part to the 2π-complement rotation vector: for `qw < 0`, `atan2(n, qw) ∈ (π/2, π]`, so the returned tangent has magnitude near 2π instead of the geodesic. Since `q` and `-q` represent the same rotation, the two representatives of one rotation disagree — `ominus` can report a ~2π error between nearly identical rotations, and scalar scaling (which round-trips through `log_map`) picks the long way around.

This is the Rust twin of goromal/manif-geom-cpp#18 (same math, same fix); see that PR for how it surfaced in practice (a converged SE(3) filter's consistency metric exploding because the estimate's quaternion walked into the `qw < 0` hemisphere).

## Fix

Canonicalize the quaternion sign (`qw ≥ 0`) inside `log_map` before taking the log, so the geodesic (shortest) tangent is always returned. `ominus`, scaling, and the deprecated `Log` alias inherit the fix.

## Tests

- New `test_log_double_cover`: `log_map(q) == log_map(-q) ==` the generating tangent for random rotations with zero-centered tangents.
- Existing tests are unaffected — worth noting this is because `SO3::random()` builds from `Vector4::new_random()`, whose components are all in `[0, 1)`, so it only ever samples the all-positive quaternion orthant (also means `random()` is not uniform over SO(3); left alone here, but may deserve its own issue).
- `cargo test`: 33 passed; `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)